### PR TITLE
Fix provisioning

### DIFF
--- a/pkg/connector/aws_account.go
+++ b/pkg/connector/aws_account.go
@@ -637,7 +637,9 @@ func (o *accountResourceType) Grant(ctx context.Context, principal *v2.Resource,
 		}
 
 		if appUser != nil {
-			if appUser.Scope == appGroupScope && !o.connector.awsConfig.AllowGroupToDirectAssignmentConversionForProvisioning && !awsConfig.JoinAllRoles {
+			// This converts group assignment to direct assignment
+			canDirectAssign := awsConfig.JoinAllRoles || awsConfig.SamlRolesUnionEnabled
+			if appUser.Scope == appGroupScope && (!o.connector.awsConfig.AllowGroupToDirectAssignmentConversionForProvisioning || !canDirectAssign) {
 				return nil, fmt.Errorf("okta-aws-connector: connect add individual assignment for user with group assignment '%s'", appUser.Id)
 			}
 

--- a/pkg/connector/aws_account.go
+++ b/pkg/connector/aws_account.go
@@ -637,7 +637,7 @@ func (o *accountResourceType) Grant(ctx context.Context, principal *v2.Resource,
 		}
 
 		if appUser != nil {
-			if appUser.Scope == appGroupScope && (!o.connector.awsConfig.AllowGroupToDirectAssignmentConversionForProvisioning || !awsConfig.JoinAllRoles) {
+			if appUser.Scope == appGroupScope && !(o.connector.awsConfig.AllowGroupToDirectAssignmentConversionForProvisioning || awsConfig.JoinAllRoles) {
 				return nil, fmt.Errorf("okta-aws-connector: connect add individual assignment for user with group assignment '%s'", appUser.Id)
 			}
 

--- a/pkg/connector/aws_account.go
+++ b/pkg/connector/aws_account.go
@@ -637,7 +637,7 @@ func (o *accountResourceType) Grant(ctx context.Context, principal *v2.Resource,
 		}
 
 		if appUser != nil {
-			if appUser.Scope == appGroupScope && !o.connector.awsConfig.AllowGroupToDirectAssignmentConversionForProvisioning || !awsConfig.JoinAllRoles {
+			if appUser.Scope == appGroupScope && (!o.connector.awsConfig.AllowGroupToDirectAssignmentConversionForProvisioning || !awsConfig.JoinAllRoles) {
 				return nil, fmt.Errorf("okta-aws-connector: connect add individual assignment for user with group assignment '%s'", appUser.Id)
 			}
 

--- a/pkg/connector/aws_account.go
+++ b/pkg/connector/aws_account.go
@@ -640,7 +640,7 @@ func (o *accountResourceType) Grant(ctx context.Context, principal *v2.Resource,
 			// This converts group assignment to direct assignment
 			canDirectAssign := awsConfig.JoinAllRoles || awsConfig.SamlRolesUnionEnabled
 			if appUser.Scope == appGroupScope && (!o.connector.awsConfig.AllowGroupToDirectAssignmentConversionForProvisioning || !canDirectAssign) {
-				return nil, fmt.Errorf("okta-aws-connector: connect add individual assignment for user with group assignment '%s'", appUser.Id)
+				return nil, fmt.Errorf("okta-aws-connector: cannot add individual assignment for user with group assignment '%s'", appUser.Id)
 			}
 
 			appUserProfile := getOrCreateAppUserProfile(ctx, appUser)

--- a/pkg/connector/aws_account.go
+++ b/pkg/connector/aws_account.go
@@ -637,7 +637,7 @@ func (o *accountResourceType) Grant(ctx context.Context, principal *v2.Resource,
 		}
 
 		if appUser != nil {
-			if appUser.Scope == appGroupScope && !(o.connector.awsConfig.AllowGroupToDirectAssignmentConversionForProvisioning || awsConfig.JoinAllRoles) {
+			if appUser.Scope == appGroupScope && !o.connector.awsConfig.AllowGroupToDirectAssignmentConversionForProvisioning && !awsConfig.JoinAllRoles {
 				return nil, fmt.Errorf("okta-aws-connector: connect add individual assignment for user with group assignment '%s'", appUser.Id)
 			}
 


### PR DESCRIPTION
Before:
<img width="2508" height="1668" alt="image" src="https://github.com/user-attachments/assets/6973cfd2-6c65-46ae-9d51-945b233c096a" />
<img width="2194" height="1926" alt="image" src="https://github.com/user-attachments/assets/c899fb56-3494-45b4-8474-6d61a383601c" />

Ticket:


<img width="1868" height="1348" alt="image" src="https://github.com/user-attachments/assets/2be2f7f1-2ff6-4b16-a92f-6ed80bc7b5da" />


After:


<img width="2618" height="1082" alt="image" src="https://github.com/user-attachments/assets/00432da1-f77d-4e77-85a6-e774a8f458b5" />
<img width="1580" height="1548" alt="image" src="https://github.com/user-attachments/assets/35cdf60e-1e41-4c68-8db8-2056e065cf2d" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected evaluation of user-group grant logic so group-scoped users are evaluated only when both group-to-direct conversion and role-joining settings require it.
  * Prevents unintended role joins or automatic direct-assignment conversions when relevant configuration flags are disabled.
  * Ensures role assignment and joining behavior now reliably respects configuration, avoiding misapplied permissions for group-scoped users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->