### PR TITLE
docs: correct the README data model and document the paired Okta connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,12 @@ the Okta users assigned to the application, and to the Okta groups assigned to i
 
 ## Group membership and the paired Okta connector
 
-This connector reads AWS role access; it does not read Okta group membership. Grants it emits
-to a group principal carry an annotation pointing at that group's `member` entitlement, and
-C1's grant expansion resolves those against a **separate Okta connector** synced from the same
-Okta organization. Two consequences worth knowing before you deploy it:
+This connector reads AWS role access; it does not read Okta group membership. The groups
+themselves, and the membership behind them, are imported into C1 from a **separate Okta
+connector** synced from the same Okta organization, configured as the application's shared
+identity source. Grants this connector emits to a group principal carry an annotation pointing
+at that group's `member` entitlement, and C1's grant expansion links the two — it does not
+create them. Two consequences worth knowing before you deploy it:
 
 - An Okta connector for the same organization must exist alongside this one. Without it, the
   group membership behind AWS role access does not resolve.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # `baton-okta-aws-federation` [![Go Reference](https://pkg.go.dev/badge/github.com/conductorone/baton-okta-aws-federation.svg)](https://pkg.go.dev/github.com/conductorone/baton-okta-aws-federation) ![ci](https://github.com/conductorone/baton-okta-aws-federation/actions/workflows/ci.yaml/badge.svg) ![verify](https://github.com/conductorone/baton-okta-aws-federation/actions/workflows/verify.yaml/badge.svg)
 
-`baton-okta-aws-federation` is a connector for Okta built using the [Baton SDK](https://github.com/conductorone/baton-sdk). It communicates with the Okta API to sync data about which groups and users have access to applications, groups, and roles within an Okta domain.
+`baton-okta-aws-federation` is a connector for Okta built using the [Baton SDK](https://github.com/conductorone/baton-sdk). It governs a single AWS Account Federation SAML application inside an Okta organization: it syncs the AWS accounts reachable through that application, the SAML roles available in each, and who holds them.
 
 Check out [Baton](https://github.com/conductorone/baton) to learn more about the project in general.
 
@@ -13,24 +13,14 @@ Check out [Baton](https://github.com/conductorone/baton) to learn more about the
 ```
 brew install conductorone/baton/baton conductorone/baton/baton-okta-aws-federation
 
-BATON_API_TOKEN=oktaAPIToken BATON_DOMAIN=domain-1234.okta.com baton-okta-aws-federation
-baton resources
-```
-
-Or auth using a public/private keypair
-
-```
-BATON_OKTA_CLIENT_ID=appClientID \
-BATON_OKTA_PRIVATE_KEY='auth.key' \
-BATON_OKTA_PRIVATE_KEY_ID=appKID \
-BATON_DOMAIN=domain-1234.okta.com baton-okta-aws-federation
+BATON_API_TOKEN=oktaAPIToken BATON_DOMAIN=domain-1234.okta.com BATON_AWS_OKTA_APP_ID=awsAppID baton-okta-aws-federation
 baton resources
 ```
 
 ## docker
 
 ```
-docker run --rm -v $(pwd):/out -e BATON_API_TOKEN=oktaAPIToken -e BATON_DOMAIN=domain-1234.okta.com ghcr.io/conductorone/baton-okta-aws-federation:latest -f "/out/sync.c1z"
+docker run --rm -v $(pwd):/out -e BATON_API_TOKEN=oktaAPIToken -e BATON_DOMAIN=domain-1234.okta.com -e BATON_AWS_OKTA_APP_ID=awsAppID ghcr.io/conductorone/baton-okta-aws-federation:latest -f "/out/sync.c1z"
 docker run --rm -v $(pwd):/out ghcr.io/conductorone/baton:latest -f "/out/sync.c1z" resources
 ```
 
@@ -40,56 +30,39 @@ docker run --rm -v $(pwd):/out ghcr.io/conductorone/baton:latest -f "/out/sync.c
 go install github.com/conductorone/baton/cmd/baton@main
 go install github.com/conductorone/baton-okta-aws-federation/cmd/baton-okta-aws-federation@main
 
-BATON_API_TOKEN=oktaAPIToken BATON_DOMAIN=domain-1234.okta.com baton-okta-aws-federation
+BATON_API_TOKEN=oktaAPIToken BATON_DOMAIN=domain-1234.okta.com BATON_AWS_OKTA_APP_ID=awsAppID baton-okta-aws-federation
 baton resources
 ```
 
 # Data Model
 
-`baton-okta-aws-federation` will pull down information about the following Okta resources:
+`baton-okta-aws-federation` syncs two resource types from the AWS Account Federation
+application it is pointed at:
 
-- Applications
-- Groups
-- Roles
-- Users
-- Custom-Roles
-- Resource-Sets
-- Resourceset-Bindings
+- **Accounts** — an AWS account reachable through the application. Its entitlements are the
+  SAML roles available in that account.
+- **Groups** — Okta groups that carry AWS role access. This connector does not sync groups as
+  first-class resources; the group resource type exists so that group membership can be
+  granted and revoked. See "Group membership and the paired Okta connector" below.
 
-By default, `baton-okta-aws-federation` will sync information for inactive applications. You can exclude inactive applications setting the `--sync-inactive-apps` flag to `false`.
+Grants on an account's role entitlements are emitted to two kinds of principal: directly to
+the Okta users assigned to the application, and to the Okta groups assigned to it.
 
-For syncing custom roles `--sync-custom-roles` must be provided. Its default value is `false`.
+## Group membership and the paired Okta connector
 
-We have also introduced resourceset-bindings(resourcesetID and custom roles ID) for provisioning custom roles and members.
+This connector reads AWS role access; it does not read Okta group membership. Grants it emits
+to a group principal carry an annotation pointing at that group's `member` entitlement, and
+C1's grant expansion resolves those against a **separate Okta connector** synced from the same
+Okta organization. Two consequences worth knowing before you deploy it:
 
-## Resourceset-bindings, custom roles and members(Users or Groups) usage:
+- An Okta connector for the same organization must exist alongside this one. Without it, the
+  group membership behind AWS role access does not resolve.
+- After a group membership changes, both connectors need to sync before the change is
+  reflected — the Okta connector first, because it is the source of the membership, then this
+  one, which re-runs the expansion.
 
-- Let's use some IDs for this example
-```
-Resource Set `iamkuwy3gqcfNexfQ697`
-Custom Role `cr0kuwv5507zJCtSy697`
-Member `00ujp51vjgWd6ylZ6697`
-```
-
-- Granting custom roles for users.
-```
-BATON_API_TOKEN='oktaAPIToken' BATON_DOMAIN='domain-1234.okta.com' baton-okta-aws-federation \
---grant-entitlement 'resourceset-binding:iamkuwy3gqcfNexfQ697:cr0kuwv5507zJCtSy697:member' --grant-principal-type 'user' --grant-principal '00ujp51vjgWd6ylZ6697'
-```
-
-In the previous example we granted the custom role `cr0kuwv5507zJCtSy697` to user `00ujp5a9z0rMTsPRW697`.
-
-- Revoking custom role grants(Unassigns a Member)
-```
-BATON_API_TOKEN='oktaAPIToken' BATON_DOMAIN='domain-1234.okta.com' baton-okta-aws-federation \
---revoke-grant 'resourceset-binding:iamkuwy3gqcfNexfQ697:cr0kuwv5507zJCtSy697:member:user:00ujp51vjgWd6ylZ6697'
-```
-
-- Revoking everything associated to custom role(Deletes a Binding of a Role)
-```
-BATON_API_TOKEN='oktaAPIToken' BATON_DOMAIN='domain-1234.okta.com' baton-okta-aws-federation \
-resource-set:iamkuwy3gqcfNexfQ697:bindings:custom-role:cr0kuwv5507zJCtSy697
-```
+Granting or revoking a group's `member` entitlement is dispatched to this connector, which
+calls Okta's group membership API directly.
 
 # Contributing, Support and Issues
 

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -22,7 +22,7 @@ sidebarTitle: "Okta AWS Federation"
 **This connector requires an Okta connector for the same Okta organization.** Group-based AWS role access is resolved against that connector, so set it up alongside this one. Without it, the AWS roles a user holds through a group do not appear.
 </Warning>
 
-Group membership itself is read from the paired Okta connector rather than by this connector. When a group's membership changes, sync the Okta connector first, then this one, so the change is reflected in the AWS roles shown for each user.
+The groups and their membership are imported from the paired Okta connector, not read by this one. When a group's membership changes, sync the Okta connector first, then this one, so the change is reflected in the AWS roles shown for each user.
 
 ## Gather Okta credentials 
 

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -18,6 +18,12 @@ sidebarTitle: "Okta AWS Federation"
 | Groups assigned to the AWS app | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
 | Application assignments for the AWS app | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |  |
 
+<Warning>
+**This connector requires an Okta connector for the same Okta organization.** Group-based AWS role access is resolved against that connector, so set it up alongside this one. Without it, the AWS roles a user holds through a group do not appear.
+</Warning>
+
+Group membership itself is read from the paired Okta connector rather than by this connector. When a group's membership changes, sync the Okta connector first, then this one, so the change is reflected in the AWS roles shown for each user.
+
 ## Gather Okta credentials 
 
 Configuring the connector requires you to pass in credentials generated in Okta. Gather these credentials before you move on.

--- a/docs/docs-info.md
+++ b/docs/docs-info.md
@@ -1,0 +1,51 @@
+While developing the connector, please fill out this form. This information is needed to write docs and to help other users set up the connector.
+
+## Connector capabilities
+
+1. What resources does the connector sync?
+
+    - Accounts — an AWS account reachable through the AWS Account Federation application in Okta. Its entitlements are the SAML roles available in that account.
+    - Groups — Okta groups that carry AWS role access. The group resource type is registered so that group membership can be granted and revoked; this connector does not sync group membership itself.
+
+2. Can the connector provision any resources? If so, which ones?
+
+    Yes. It grants and revokes a user's SAML role on an AWS account, and grants and revokes Okta group membership. It does not create or delete accounts.
+
+## Connector credentials
+
+1. What credentials or information are needed to set up the connector? (For example, API key, client ID and secret, domain, etc.)
+
+    - **Okta domain**: the URL for the Okta organization, for example `acmeco.okta.com`.
+    - **API token**: an Okta API token for the service account.
+    - **AWS Okta App ID**: the Okta application id of the AWS Account Federation app to govern.
+
+2. For each item in the list above:
+
+   * How does a user create or look up that credential or info? Please include links to (non-gated) documentation, screenshots (of the UI or of gated docs), or a video of the process.
+
+     * **Okta domain**: the hostname the Okta admin console is served from.
+     * **API token**: Okta Admin Console → **Security** → **API** → **Tokens** → **Create token**. The value is shown once. [Okta API token documentation](https://developer.okta.com/docs/guides/create-an-api-token/main/)
+     * **AWS Okta App ID**: open the AWS Account Federation app in the Okta Admin Console; the id is the last path segment of the URL.
+
+   * Does the credential need any specific scopes or permissions? If so, list them here.
+
+     * **API token**: the token inherits the permissions of the admin who created it. Reading requires the ability to read applications, application assignments and groups. Provisioning group membership additionally requires Group Admin.
+
+    * If applicable: Is the list of scopes or permissions different to sync (read) versus provision (read-write)? If so, list the difference here.
+
+     * **Sync (read-only)**: a custom read-only admin role, or Read Only Administrator, is sufficient.
+     * **Provisioning (read-write)**: Super Administrator, or the combination Read Only + Application Administrator + Group Administrator. Group membership provisioning fails without Group Admin.
+
+     * What level of access or permissions does the user need in order to create the credentials? (For example, must be a super administrator, must have access to the admin console, etc.)
+
+     * **API token**: the creating user must be an Okta administrator with access to the admin console. The token carries that admin's permissions.
+
+## Additional setup notes
+
+1. This connector requires a separate Okta connector for the same Okta organization. Group membership is read from that connector, and the AWS role access a user holds through a group is resolved against it. Without the paired connector, group-based access does not resolve.
+
+2. After a group membership changes, both connectors must sync before the change is reflected: the Okta connector first, because it is the source of the membership, then this connector, which re-runs the expansion.
+
+3. The connector's behaviour depends on the AWS Account Federation app's own settings in Okta, not only on connector configuration. `useGroupMapping`, `joinAllRoles` and `identityProviderArn` are read from the application and determine which accounts and roles are discovered.
+
+4. Converting a group-based application assignment into a direct one during provisioning is refused unless `--aws-allow-group-to-direct-assignment-conversion-for-provisioning` is set and the application has `joinAllRoles` or SAML role union enabled.


### PR DESCRIPTION
The README described a different connector, and neither it nor the docs page mentioned that this connector needs a paired Okta connector to be useful.

## What was wrong

Every item below was checked against the code on `main`.

| Finding | Doc | Code |
| --- | --- | --- |
| Seven resource types listed as synced | `README.md:51-57` | `pkg/connector/connector.go:122` registers two builders; `baton_capabilities.json` declares `account` and `group` |
| `--sync-inactive-apps` and `--sync-custom-roles` documented | `README.md:59`, `:61` | Neither flag exists in `pkg/` or `cmd/` — and the README own CLI usage block at `:115-136` already omits them |
| A `resourceset-binding` grant/revoke workflow documented | `README.md:63-92` | No such resource type or provisioner exists |
| Public/private keypair auth documented | `README.md:23-25` | `pkg/config/config.go:56-64` registers no client-id or private-key field |
| Opening description claims it syncs applications, groups and roles across the org | `README.md:5` | It governs one AWS Account Federation SAML app |
| Every run example omits a required field | `README.md` brew/docker/source | `aws-okta-app-id` is required (`pkg/config/config.go`), so the examples as written fail |
| No mention of the paired Okta connector | `docs/connector.mdx` | `pkg/config/config.go:68` sets `WithRequiresExternalConnector(true)`; group `member` entitlements resolve only against that connector |
| No internal docs-scoping file | `docs/` | The file has never existed in this repo |

The paired-connector item was measured, not inferred: reflecting a group membership revoke in C1 required syncing the Okta connector first and this one second. Following the page alone leaves an app whose group-based AWS role access does not appear.

## What changed

- **`README.md`** — data model rewritten around the two resource types actually synced, with a section on group membership and the paired connector; unsupported flags, workflow and auth method removed; opening description corrected; the required app id added to every run example.
- **`docs/connector.mdx`** — a warning naming the paired-connector requirement, and a note on the sync order a membership change needs. Six lines, no existing content altered.
- **`docs/docs-info.md`** — added; the repo never had one.

## What deliberately did not change

The **Groups → Sync** row in the capabilities table. It agrees with `baton_capabilities.json`, which is generated from the code by `./connector capabilities`, so editing the row alone would put the two artefacts out of step and the next metadata regeneration would revert it. `pkg/connector/group.go:48` is a stub and the group `member` entitlements come from grant expansion instead — that is now explained in prose in both files. Whether the group resource type should declare a sync capability at all is a code question and is tracked separately.

## Review focus

The paired-connector claim and the sync-order guidance are the two statements worth a second read — they are new customer-facing assertions, grounded in `pkg/config/config.go:68` and in the expansion annotation built at `pkg/connector/aws_account.go:630-650`.